### PR TITLE
On Samsung devices, we need to tell Audio HAL if we're running narrow band or wide band

### DIFF
--- a/android/app/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
+++ b/android/app/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
@@ -145,6 +145,7 @@ public class HeadsetStateMachine extends StateMachine {
     // Audio Parameters
     private boolean mHasNrecEnabled = false;
     private boolean mHasWbsEnabled = false;
+    private int mReportScoSampleRate = 0;
     // AT Phone book keeps a group of states used by AT+CPBR commands
     private final AtPhonebook mPhonebook;
     // HSP specific
@@ -225,6 +226,7 @@ public class HeadsetStateMachine extends StateMachine {
         }
         mHasWbsEnabled = false;
         mHasNrecEnabled = false;
+        mReportScoSampleRate = 0;
     }
 
     public void dump(StringBuilder sb) {
@@ -454,6 +456,7 @@ public class HeadsetStateMachine extends StateMachine {
             mNeedDialingOutReply = false;
             mHasWbsEnabled = false;
             mHasNrecEnabled = false;
+            mReportScoSampleRate = 0;
             broadcastStateTransitions();
             // Remove the state machine for unbonded devices
             if (mPrevState != null
@@ -1538,6 +1541,9 @@ public class HeadsetStateMachine extends StateMachine {
                 + " hasNrecEnabled=" + mHasNrecEnabled
                 + " hasWbsEnabled=" + mHasWbsEnabled);
         am.setBluetoothHeadsetProperties(getCurrentDeviceName(), mHasNrecEnabled, mHasWbsEnabled);
+        if (mReportScoSampleRate > 0) {
+            am.setParameters("g_sco_samplerate=" + mReportScoSampleRate);
+        }
     }
 
     private String parseUnknownAt(String atString) {
@@ -1678,10 +1684,12 @@ public class HeadsetStateMachine extends StateMachine {
         switch (wbsConfig) {
             case HeadsetHalConstants.BTHF_WBS_YES:
                 mHasWbsEnabled = true;
+                mReportScoSampleRate = 16000;
                 break;
             case HeadsetHalConstants.BTHF_WBS_NO:
             case HeadsetHalConstants.BTHF_WBS_NONE:
                 mHasWbsEnabled = false;
+                mReportScoSampleRate = 8000;
                 break;
             default:
                 Log.e(TAG, "processWBSEvent: unknown wbsConfig " + wbsConfig);


### PR DESCRIPTION
Original at https://github.com/phhusson/platform_packages_apps_Bluetooth/commit/a1f3e0229c1043205ddf995e534e783c75027a75

Ported to Android 13.

Tested and working in "production" without any impact on other devices using PE v2022.11.13 and PE+ v2022.11.24.

