### PR TITLE
Add property to disable APCF extended features

### DIFF
--- a/system/gd/hci/le_scanning_manager.cc
+++ b/system/gd/hci/le_scanning_manager.cc
@@ -60,7 +60,7 @@ constexpr uint8_t kDataStatusBits = 5;
 
 // system properties
 const std::string kLeRxPathLossCompProperty = "bluetooth.hardware.radio.le_rx_path_loss_comp_db";
-const std::string kPropertyDisableApcfExtendedFeatures = "bluetooth.le.disable_apcf_extended_features";
+const std::string kPropertyDisableApcfExtendedFeatures = "persist.sys.bt.le.disable_apcf_extended_features";
 bool kDisableApcfExtendedFeatures = false;
 
 const ModuleFactory LeScanningManager::Factory =

--- a/system/gd/hci/le_scanning_manager.cc
+++ b/system/gd/hci/le_scanning_manager.cc
@@ -60,6 +60,8 @@ constexpr uint8_t kDataStatusBits = 5;
 
 // system properties
 const std::string kLeRxPathLossCompProperty = "bluetooth.hardware.radio.le_rx_path_loss_comp_db";
+const std::string kPropertyDisableApcfExtendedFeatures = "bluetooth.le.disable_apcf_extended_features";
+bool kDisableApcfExtendedFeatures = false;
 
 const ModuleFactory LeScanningManager::Factory =
         ModuleFactory([]() { return new LeScanningManager(); });
@@ -190,7 +192,9 @@ struct LeScanningManager::impl : public LeAddressManagerCallback {
       api_type_ = ScanApiType::LEGACY;
     }
     is_filter_supported_ = controller_->IsSupported(OpCode::LE_ADV_FILTER);
-    if (is_filter_supported_) {
+    if (os::GetSystemProperty(kPropertyDisableApcfExtendedFeatures) == "1")
+       kDisableApcfExtendedFeatures = true;
+     if (is_filter_supported_ && !kDisableApcfExtendedFeatures) {
       le_scanning_interface_->EnqueueCommand(
               LeAdvFilterReadExtendedFeaturesBuilder::Create(),
               module_handler_->BindOnceOn(this, &impl::on_apcf_read_extended_features_complete));


### PR DESCRIPTION
* It's broken on some legacy devices, rendering Bluetooth crashing

Change-Id: I4b1764b7551150e78dd8e2dfc99a6472c1293c2b


ChonDoit: Confirmed fix perma crashing on Moto G50 5G

Source of crash:
03-06 03:10:30.900 E/bluetooth( 3393): packages/modules/Bluetooth/system/gd/hci/le_scanning_manager.cc:1113 - update_ad_type_filter: AD type filter isn't supported