### PR TITLE
Bluetooth audio fix for Lenovo Y700 gen4 (TB322FC). [3/3]

### DIFF
--- a/system/audio_hal_interface/aidl/a2dp/codec_status_aidl.cc
+++ b/system/audio_hal_interface/aidl/a2dp/codec_status_aidl.cc
@@ -508,8 +508,8 @@ bool UpdateOffloadingCapabilities(
         break;
       case BTAV_A2DP_CODEC_INDEX_MAX:
       default:
-        log::error("Unknown codec_type={}", preference.codec_type);
-        return false;
+        log::error("Unknown codec_type={}. Ignore.", preference.codec_type);
+        break;
     }
   }
   offloading_preference.clear();

--- a/system/audio_hal_interface/hidl/codec_status_hidl.cc
+++ b/system/audio_hal_interface/hidl/codec_status_hidl.cc
@@ -469,8 +469,8 @@ bool UpdateOffloadingCapabilities(
         break;
       case BTAV_A2DP_CODEC_INDEX_MAX:
       default:
-        log::error("Unknown codec_type={}", preference.codec_type);
-        return false;
+        log::error("Unknown codec_type={}. Ignore.", preference.codec_type);
+        break;
     }
   }
   offloading_preference.clear();


### PR DESCRIPTION
This is a part of patch series to fix bluetooth audio Lenovo Y700 gen4 (TB322FC).

Some qualcomm devices reports the offload codecs like Apt-X Adaptive which isn't supported by AOSP. The implementation stops processing the codecs list after stumbled on an unsupported codec. This behaviour let a2dp connection fail. This commit changes it to just ignores the unsupported codecs.

Lenovo's (or qualcomm's) bluetooth stack seems to have this change. Related fix on codelinaro:
https://git.codelinaro.org/clo/la/platform/vendor/qcom-opensource/packages/modules/Bluetooth/-/commit/defac8ee01045025d871f3efd2df4ae3ff47d63f

First part:
https://github.com/TrebleDroid/treble_app/pull/49